### PR TITLE
Upgrade to tcomb@^0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ validate('left', CssTextAlign).isValid();   // => true
 ```js
 var CssLineHeight = union([Num, Str]);
 
-// in order to make it work, we must implement the #dispath method
+// in order to make it work, we must implement the #dispatch method
 CssLineHeight.dispatch = function (x) {
   if (Num.is(x)) { return Num; }
   else if (Str.is(x)) { return Str; }
@@ -199,8 +199,9 @@ validate('1.2em', CssLineHeight).isValid(); // => true
 ## Dicts
 
 ```js
-// a dictionary of numbers
-var Warranty = dict(Num);
+// a dictionary mapping strings to numbers, note that while all dictionaries  have
+// string keys, it's possible to further restrict the domain of keys with subtyping.
+var Warranty = dict(Str, Num);
 
 validate(null, Warranty).isValid();             // => false
 validate({US: 2, IT: 'a'}, Warranty).isValid(); // => false, ['IT'] is not a number

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@
   var maybe = t.maybe;
   var list = t.list;
 
-  var isType = t.util.isType;
+  var isType = t.Type.is;
   var assert = t.assert;
   var getName = t.util.getName;
   var mixin = t.util.mixin;
@@ -241,7 +241,12 @@
     var errors = [];
     for (var k in value) {
       if (value.hasOwnProperty(k)) {
-        var result = _validate(value[k], type.meta.type, {path: opts.path.concat([k]), messages: getMessage(opts.messages, ':type')});
+        var keyResult = _validate(k, type.meta.domain, {path: opts.path, messages: getMessage(opts.messages, ':domain')});
+        if (!keyResult.isValid()) {
+          isValid = false;
+          errors = errors.concat(result.errors);
+        }
+        var result = _validate(value[k], type.meta.codomain, {path: opts.path.concat([k]), messages: getMessage(opts.messages, ':codomain')});
         if (!result.isValid()) {
           isValid = false;
           errors = errors.concat(result.errors);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/gcanti/tcomb-validation",
   "dependencies": {
-    "tcomb": "~0.2.1"
+    "tcomb": "^0.3.1"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/test/test.js
+++ b/test/test.js
@@ -104,7 +104,8 @@ Price.dispatch = function (value) {
 
 var Size = tuple([Num, Num], 'Size');
 
-var Warranty = dict(Num, 'Warranty');
+debugger
+var Warranty = dict(Str, Num, 'Warranty');
 
 var Product = struct({
   name:       Str,                  
@@ -250,7 +251,7 @@ describe('validate', function () {
       eqv(validate(1, Warranty, {messages: 'mymessage'}), result('mymessage', [], 1, Obj));
       eqv(validate({x: 'a'}, Warranty, {messages: 'mymessage'}), result('mymessage', ['x'], 'a', Num));
       eqv(validate(1, Warranty, {messages: {':input': 'should be a list'}}), result('should be a list', [], 1, Obj));
-      eqv(validate({x: 'a'}, Warranty, {messages: {':type': 'should be a string'}}), result('should be a string', ['x'], 'a', Num));
+      eqv(validate({x: 'a'}, Warranty, {messages: {':codomain': 'should be a string'}}), result('should be a string', ['x'], 'a', Num));
     });
   });
 
@@ -286,7 +287,7 @@ describe('validate', function () {
         category:   'category should be a valid enum',         
         price:      {':dispatch': 'price should be expressed in dollars or in another currency', 0: 'price should be a positive number', 1: {':struct': 'price should be an object', currency: 'currency should be a currency', amount: 'amount should be a positive number'}},
         size:        {':input': 'size should be an array of length 2', 0: 'size.width should be a number', 1: 'size.height should be a number'},
-        warranty:  {':input': 'warranty should be a dict of numbers', ':type': 'every element of warranty should be a number'},       
+        warranty:  {':input': 'warranty should be a dict of numbers', ':codomain': 'every element of warranty should be a number'},       
       };
 
       it('should return custom messages', function () {


### PR DESCRIPTION
This tcomb version changed the meta properties of dict types and removed 
t.util.isType.
