### PR TITLE
correctly validate a union of structs

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,7 +198,13 @@
   };
 
   validators.union = function validateUnion(x, type, path) {
-    var ctor = type.dispatch(x);
+    var ctor = false
+    for (var i=0; i<type.meta.types.length; i++) {
+      if (recurse(x, type.meta.types[i], path).errors.length === 0) {
+        ctor = type.meta.types[i]
+        break
+      }
+    }
     return t.Func.is(ctor)?
       recurse(x, ctor, path.concat(type.meta.types.indexOf(ctor))) :
       {value: x, errors: [ValidationError.of(x, type, path)]};

--- a/test/test.js
+++ b/test/test.js
@@ -134,6 +134,13 @@ describe('validate()', function () {
     eq(validate(true, Union), failure(true, Union, [], '/ is `true` should be a `Union`', true));
   });
 
+  it('union of structs', function () {
+    var Union = t.union([t.struct({one: Str}), t.struct({two: Num})], 'Union');
+    eq(validate({one: 'val'}, Union), success({one: 'val'}));
+    eq(validate({two: 3}, Union), success({two: 3}));
+    eq(validate({one: 2}, Union), failure({one: 2}, Union, [], '/ is `{"one":2}` should be a `Union`', {one: 2}));
+  });
+
   it('optional `path` param', function () {
     eq(validate(1, Str, ['prefix']), failure(1, Str, ['prefix'], '/prefix is `1` should be a `Str`', 1));
   });


### PR DESCRIPTION
`type.dispatch` on union doesn't work, because it uses `.is`, which on `struct`s goes to `instanceof`. 

tcomb-validation already has the logic for structs at the top level, and this extends it to work within unions.