### PR TITLE
ValidationError: relax message type (from String to Any)

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var stringify = t.stringify;
 var noobj = {};
 
 var ValidationError = t.struct({
-  message: t.String,
+  message: t.Any,
   actual: t.Any,
   expected: t.Any,
   path: t.list(t.union([t.String, t.Number]))
@@ -55,7 +55,7 @@ ValidationResult.prototype.toString = function () {
   }
   else {
     return '[ValidationResult, false, (' + this.errors.map(function (err) {
-      return err.message;
+      return stringify(err.message);
     }).join(', ') + ')]';
   }
 };

--- a/test/index.js
+++ b/test/index.js
@@ -353,5 +353,30 @@ describe('getValidationErrorMessage(value, context)', function () {
     eq(validate('aaa', Intersection), failure('aaa', ShortString, [], 'Too long my friend', 'aaa'));
   });
 
+  it('should allow to return custom validation objects', function () {
+    ShortString.getValidationErrorMessage = function (value) {
+      if (!ShortString.is(value)) {
+        return { foo: 'bar' };
+      }
+    };
+    eq(validate('aaa', ShortString), failure('aaa', ShortString, [], { foo: 'bar' }, 'aaa'));
+  });
+
 });
 
+describe('ValidationResult.toString', function () {
+  it('should return string representation when valid', function () {
+    const res = success(true);
+    eq('[ValidationResult, true, true]', res.toString());
+  });
+
+  it('should return string representation when invalid', function () {
+    const res = failure(1, t.String, [], 'Invalid value 1 supplied to String', 1);
+    eq('[ValidationResult, false, ("Invalid value 1 supplied to String")]', res.toString());
+  });
+
+  it('should return string representation when invalid with custom message', function () {
+    const res = failure(1, t.String, [], { very: 'error' }, 1);
+    eq('[ValidationResult, false, ({\n  "very": "error"\n})]', res.toString());
+  });
+});


### PR DESCRIPTION
In some applications the user may want to separate validation logic from
error generation and i18n. This allows to to return any kind of data as
`message` so that the UI can use it to do further processing.

This code could look a little unclean. A better solution that doesn't
break backwards compatibility would be to add a new API similar to
`getValidationErrorMessage`, but that would require a lot of work and code
complexity for a not very important use case.

Fixes: #53