### PR TITLE
pass context to predicate

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ validators.subtype = function validateSubtype(x, type, path, options) {
   }
 
   // x should satisfy the predicate
-  if (!type.meta.predicate(ret.value)) {
+  if (!type.meta.predicate(ret.value, options.context)) {
     ret.errors = [ValidationError.of(x, type, path, options.context)];
   }
 


### PR DESCRIPTION
allows handling dependent fields better. Person struct can be complex and having to set Person as a refinement on struct and then handle all dependent field in one predicate is not ideal imo.

```
isValidConfirmPassword = (confirmPassword, context) => context.password === confirmPassword;

const ConfirmPassword = t.refinement(t.String, isValidConfirmPassword);

const Person = t.struct({
  name: t.String,
  password: t.String,
  confirmPassword: ConfirmPassword,
  // ...can have multiple dependent fields here.
}, 'Person');

const formValues = { name: 'a', password: 'b', confirmPassword: 'c' };

validate(formValues, Person, { context: formValues });
```


cc @itajaja