### PR TITLE
Fix recursive type definition error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,8 +2,9 @@ import * as t from 'tcomb';
 
 export * from 'tcomb';
 
+// Augment 'tcomb': Add getValidationErrorMessage.
 declare module 'tcomb' {
-    export interface Type<T> extends t.Type<T> {
+    export interface Type<T> {
         /**
          * Allows customization of the error message for a type.
          * 
@@ -56,7 +57,7 @@ export interface ValidationResult {
      */
     firstError(): ValidationError | null;
     /**
-     * Contains the validation errors, if any.
+     * Contains the validation errors, if any. Empty if none.
      */
     errors: Array<ValidationError>;
 }


### PR DESCRIPTION
This fixes an error that can occur with the extended t.Type<T>:

`error TS2310: Type 'Type<T>' recursively references itself as a base type.`

My apologies for any problem this might have caused. I misunderstood how interface augmentation worked; TypeScript seems to make an union of the types; extension is not required.

For reference: [https://www.typescriptlang.org/docs/handbook/declaration-merging.html](https://www.typescriptlang.org/docs/handbook/declaration-merging.html)